### PR TITLE
주문에 라이더 배차 기능 구현

### DIFF
--- a/src/main/java/ksh/deliverymate/global/config/ExceptionMessageConfig.java
+++ b/src/main/java/ksh/deliverymate/global/config/ExceptionMessageConfig.java
@@ -1,0 +1,21 @@
+package ksh.deliverymate.global.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+public class ExceptionMessageConfig {
+
+    @Bean
+    public MessageSource exceptionMessageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
+        messageSource.setUseCodeAsDefaultMessage(true);
+        return messageSource;
+    }
+}

--- a/src/main/java/ksh/deliverymate/global/config/ExceptionMessageConfig.java
+++ b/src/main/java/ksh/deliverymate/global/config/ExceptionMessageConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 @Configuration
 public class ExceptionMessageConfig {
@@ -16,6 +17,8 @@ public class ExceptionMessageConfig {
         messageSource.setBasename("classpath:messages");
         messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
         messageSource.setUseCodeAsDefaultMessage(true);
+        messageSource.setFallbackToSystemLocale(false);
+        messageSource.setDefaultLocale(Locale.KOREA);
         return messageSource;
     }
 }

--- a/src/main/java/ksh/deliverymate/global/dto/response/ErrorResponseDto.java
+++ b/src/main/java/ksh/deliverymate/global/dto/response/ErrorResponseDto.java
@@ -1,0 +1,26 @@
+package ksh.deliverymate.global.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponseDto {
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    public static ErrorResponseDto of(int status, String code, String message) {
+        return new ErrorResponseDto(status, code, message);
+    }
+
+    public static ErrorResponseDto error() {
+        return new ErrorResponseDto(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            HttpStatus.INTERNAL_SERVER_ERROR.name(),
+            "Internal Server Error"
+        );
+    }
+}

--- a/src/main/java/ksh/deliverymate/global/dto/response/ErrorResponseDto.java
+++ b/src/main/java/ksh/deliverymate/global/dto/response/ErrorResponseDto.java
@@ -2,7 +2,6 @@ package ksh.deliverymate.global.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -14,13 +13,5 @@ public class ErrorResponseDto {
 
     public static ErrorResponseDto of(int status, String code, String message) {
         return new ErrorResponseDto(status, code, message);
-    }
-
-    public static ErrorResponseDto error() {
-        return new ErrorResponseDto(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-            HttpStatus.INTERNAL_SERVER_ERROR.name(),
-            "Internal Server Error"
-        );
     }
 }

--- a/src/main/java/ksh/deliverymate/global/exception/CustomException.java
+++ b/src/main/java/ksh/deliverymate/global/exception/CustomException.java
@@ -1,0 +1,19 @@
+package ksh.deliverymate.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final List<Object> messageArgs;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.messageArgs = List.of();
+    }
+}

--- a/src/main/java/ksh/deliverymate/global/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliverymate/global/exception/ErrorCode.java
@@ -1,0 +1,14 @@
+package ksh.deliverymate.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    ORDER_ALREADY_ASSIGNED_RIDER(400, "order.already.assigned.rider"),;
+
+    private final int status;
+    private final String messageKey;
+}

--- a/src/main/java/ksh/deliverymate/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/ksh/deliverymate/global/exception/GlobalControllerAdvice.java
@@ -1,0 +1,48 @@
+package ksh.deliverymate.global.exception;
+
+import ksh.deliverymate.global.dto.response.ErrorResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Locale;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalControllerAdvice {
+
+    private final MessageSource messageSource;
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponseDto> handleCustomException(CustomException e, Locale locale) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        String errorMessage = messageSource.getMessage(
+            errorCode.getMessageKey(),
+            e.getMessageArgs().toArray(),
+            locale
+        );
+
+        ErrorResponseDto response = ErrorResponseDto.of(
+            errorCode.getStatus(),
+            errorCode.name(),
+            errorMessage
+        );
+
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleException(Exception e, Locale locale) {
+        ErrorResponseDto response = ErrorResponseDto.error();
+
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(response);
+    }
+}

--- a/src/main/java/ksh/deliverymate/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/ksh/deliverymate/global/exception/GlobalControllerAdvice.java
@@ -39,7 +39,11 @@ public class GlobalControllerAdvice {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleException(Exception e, Locale locale) {
-        ErrorResponseDto response = ErrorResponseDto.error();
+        ErrorResponseDto response = ErrorResponseDto.of(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            HttpStatus.INTERNAL_SERVER_ERROR.name(),
+            "Internal Server Error"
+        );
 
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/ksh/deliverymate/order/controller/OrderController.java
+++ b/src/main/java/ksh/deliverymate/order/controller/OrderController.java
@@ -3,14 +3,15 @@ package ksh.deliverymate.order.controller;
 import jakarta.validation.Valid;
 import ksh.deliverymate.global.dto.request.PageRequestDto;
 import ksh.deliverymate.global.dto.response.PageResponseDto;
+import ksh.deliverymate.order.dto.request.RiderAssignmentRequestDto;
 import ksh.deliverymate.order.dto.request.WaitingRiderOrderRequestDto;
 import ksh.deliverymate.order.dto.response.WaitingRiderOrderResponseDto;
 import ksh.deliverymate.order.facade.OrderFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +30,16 @@ public class OrderController {
             .map(WaitingRiderOrderResponseDto::from);
 
         return ResponseEntity.ok(PageResponseDto.of(dtoSlice));
+    }
+
+    @PostMapping("/orders/waiting")
+    public ResponseEntity<Void> assignRider(
+        @Valid @RequestBody RiderAssignmentRequestDto requestDto
+    ) {
+        orderFacade.assignRider(requestDto.getId(), requestDto.getRiderId());
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build();
     }
 }

--- a/src/main/java/ksh/deliverymate/order/dto/request/RiderAssignmentRequestDto.java
+++ b/src/main/java/ksh/deliverymate/order/dto/request/RiderAssignmentRequestDto.java
@@ -1,0 +1,16 @@
+package ksh.deliverymate.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RiderAssignmentRequestDto {
+
+    @NotNull(message = "주문 id는 필수입니다.")
+    private Long id;
+
+    @NotNull(message = "주문에 배정할 라이더의 id는 필수입니다.")
+    private Long riderId;
+}

--- a/src/main/java/ksh/deliverymate/order/entity/Order.java
+++ b/src/main/java/ksh/deliverymate/order/entity/Order.java
@@ -41,4 +41,9 @@ public class Order extends BaseEntity {
     @SQLDelete(sql = "update order set is_deleted = true where id = ?")
     @Where(clause = "isDeleted = 0")
     private boolean isDeleted;
+
+    public void assignRider(long riderId) {
+        this.riderId = riderId;
+        this.status = OrderStatus.ASSIGNED;
+    }
 }

--- a/src/main/java/ksh/deliverymate/order/facade/OrderFacade.java
+++ b/src/main/java/ksh/deliverymate/order/facade/OrderFacade.java
@@ -50,6 +50,10 @@ public class OrderFacade {
         );
     }
 
+    public void assignRider(long id, long riderId) {
+        orderService.assignRider(id, riderId);
+    }
+
     private static List<Long> extractOrderIdsFrom(Slice<OrderWithStore> orderStoreInfos) {
         return orderStoreInfos.stream()
             .map(OrderWithStore::getOrderId)

--- a/src/main/java/ksh/deliverymate/order/repository/OrderRepository.java
+++ b/src/main/java/ksh/deliverymate/order/repository/OrderRepository.java
@@ -1,7 +1,14 @@
 package ksh.deliverymate.order.repository;
 
+import jakarta.persistence.LockModeType;
 import ksh.deliverymate.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryRepository {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Order> findByIdAndRiderIdIsNull(long id);
 }

--- a/src/main/java/ksh/deliverymate/order/repository/OrderRepository.java
+++ b/src/main/java/ksh/deliverymate/order/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package ksh.deliverymate.order.repository;
 
 import jakarta.persistence.LockModeType;
 import ksh.deliverymate.order.entity.Order;
+import ksh.deliverymate.order.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 
@@ -10,5 +11,5 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryRepository {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<Order> findByIdAndRiderIdIsNull(long id);
+    Optional<Order> findByIdAndStatusAndRiderIdIsNull(long id, OrderStatus status);
 }

--- a/src/main/java/ksh/deliverymate/order/service/OrderService.java
+++ b/src/main/java/ksh/deliverymate/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package ksh.deliverymate.order.service;
 
+import ksh.deliverymate.global.exception.CustomException;
+import ksh.deliverymate.global.exception.ErrorCode;
 import ksh.deliverymate.order.entity.OrderStatus;
 import ksh.deliverymate.order.repository.OrderRepository;
 import ksh.deliverymate.order.repository.projection.OrderWithStore;
@@ -28,5 +30,12 @@ public class OrderService {
             radius,
             pageable
         );
+    }
+
+    @Transactional
+    public void assignRider(long id, long riderId) {
+        orderRepository.findByIdAndRiderIdIsNull(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_ALREADY_ASSIGNED_RIDER))
+            .assignRider(riderId);
     }
 }

--- a/src/main/java/ksh/deliverymate/order/service/OrderService.java
+++ b/src/main/java/ksh/deliverymate/order/service/OrderService.java
@@ -34,7 +34,7 @@ public class OrderService {
 
     @Transactional
     public void assignRider(long id, long riderId) {
-        orderRepository.findByIdAndRiderIdIsNull(id)
+        orderRepository.findByIdAndStatusAndRiderIdIsNull(id, OrderStatus.ACCEPTED)
             .orElseThrow(() -> new CustomException(ErrorCode.ORDER_ALREADY_ASSIGNED_RIDER))
             .assignRider(riderId);
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+order.already.assigned.rider="이미 라이더가 배정된 주문입니다"


### PR DESCRIPTION
# 📝 주요 구현 사항
## 라이더 배차 (POST: /orders/waiting)
라이더가 주문을 선택하여 자신의 ID와 함께 요청을 보내면,
해당 주문의 riderId가 null인지 확인합니다.
- 만약 riderId가 이미 존재한다면, 해당 주문은 다른 라이더에게 배정된 상태이므로 예외를 발생시킵니다.
- riderId가 null이라면, 주문 상태를 ASSIGNED로 변경하고 요청한 라이더의 ID를 할당합니다.

배차 시 동시성 문제를 방지하기 위해 비관적 쓰기락을 사용하여 주문 엔티티를 조회합니다

### 응답
현재 배차 성공 후 반화되는 응답의 본문은 비워뒀습니다.
이는 주문 목록 조회 시 이미 가게 정보 및 주문 품목을 제공했기 때문으로, 화면에 해당 정보가 남아 있다고 판단하여 정상 처리 여부만 반환합니다.

# 해야할 일
- 비관적 쓰기락을 MySQL named 락을 이용하여 성능을 개선할 예정입니다.
